### PR TITLE
No longer need to convert out pyarrow stuff - simplifies notebook

### DIFF
--- a/notebooks/00_template_notebook.ipynb
+++ b/notebooks/00_template_notebook.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "c45c4dcc-84e9-4471-b374-4758e4b59fe3",
    "metadata": {
     "editable": true,
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "fccbd514-b68e-4c44-b9a0-f0dbe01ec604",
    "metadata": {},
    "outputs": [],
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "59bdfe12-c0dc-48c2-b5dd-b928c633da79",
    "metadata": {},
    "outputs": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "2f80b090-74fe-4a2c-a2b8-574dfd64b74a",
    "metadata": {
     "editable": true,
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "ee696384-b4f1-48aa-911a-28e636f12361",
    "metadata": {},
    "outputs": [],
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "fbef1df9-59ae-4451-9376-71b9e54cd276",
    "metadata": {},
    "outputs": [
@@ -788,16 +788,13 @@
        "zossq                                         m2  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "datastore_filtered = datastore.search(realm=\"ocean\", frequency=\"1mon\")\n",
-    "\n",
-    "for col in COLUMNS_WITH_ITERABLES:\n",
-    "    datastore_filtered.df[col] = datastore_filtered.df[col].astype(\"object\").map(lambda x: list(map(str, x)))\n",
     "\n",
     "available_variables(datastore_filtered)"
    ]
@@ -950,7 +947,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:analysis3-25.09]",
+   "display_name": "Python [conda env:analysis3-25.09] *",
    "language": "python",
    "name": "conda-env-analysis3-25.09-py"
   },


### PR DESCRIPTION
Reverts the hacky workaround from https://github.com/ACCESS-Community-Hub/access-om3-paper-1/pull/37/.

I should have done this sooner. @chrisb13 are there any other examples of this snippet of code that need cleaning out?