### PR TITLE
Raise on ambiguous dataset matches in `select_variable`

### DIFF
--- a/notebooks/model_agnostic.py
+++ b/notebooks/model_agnostic.py
@@ -165,6 +165,7 @@ def select_variable(
         Open an intake-esm catalog search result.
         - If exactly one dataset key: use to_dask()
         - If multiple: use to_dataset_dict(), choose 'best' based on prefer_dims, normalize zl->z_l
+        - If prefer_dims cannot single out one dataset: raise rather than pick arbitrarily
         """
         open_kwargs = dict(chunks=chunks, decode_timedelta=True, use_cftime=True)
         combine_kwargs = dict(compat="override", coords="minimal", data_vars="minimal")
@@ -186,7 +187,15 @@ def select_variable(
             dims = set(ds.dims)
             return tuple(int(d in dims) for d in prefer_dims)
 
-        best_key = max(ds_dict.keys(), key=lambda k: ds_score(ds_dict[k]))
+        scores = {key: ds_score(ds) for key, ds in ds_dict.items()}
+        best_score = max(scores.values())
+        best_keys = sorted(key for key, score in scores.items() if score == best_score)
+        if len(best_keys) > 1:
+            raise RuntimeError(
+                f"Ambiguous match: cannot choose between dataset keys {best_keys}. "
+                "Refine the search (variable name, frequency, ...) to match exactly one dataset."
+            )
+        best_key = best_keys[0]
         ds = ds_dict[best_key]
 
         # Normalize vertical dim name for downstream code


### PR DESCRIPTION
Previously, when a catalog search matched multiple datasets, `_open_cat_best_dataset` picked one with max() over a mostly-tied score — for 2D fields this silently returned an arbitrary dataset (e.g. `sos_min` instead of `sos`). It now raises a RuntimeError listing the ambiguous dataset keys so the caller must refine the search; the prefer_dims ranking (`z_l` over `zl`) still resolves the cases it can.

Verified on the ACCESS-CM3 datastore, where `sea_surface_temperature` at 1mon matches both `tos_max` and `tos_min`: the CF lookup now fails and the variable-name fallback resolves deterministically to the daily-mean `tos`.

Addresses [this comment](https://github.com/ACCESS-Community-Hub/access-om3-paper-1/blob/720efefe0421a5349b6a232d870eddba22abb73a/notebooks/model_agnostic.py#L189).